### PR TITLE
TT-1082: Add env parameter to specify REST service path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ LANGUAGES=mul,eng,nob
 
 # and optionally, to restrict the detection to a subset of languages
 # GIELLADETECT_LANGS=nno,nob,eng,swe,fin
+
+# To have Meteor run on a different path (only for stage and prod environments), set
+# CUSTOM_PATH=/meteor-custom-path

--- a/src/settings.py
+++ b/src/settings.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     REGISTRY_PASSWORD: str = ""
     USE_GIELLADETECT: bool = False
     GIELLADETECT_LANGS: str = ""
+    CUSTOM_PATH: str = ""
 
     class Config:
         """Specify name of settings file"""

--- a/src/util.py
+++ b/src/util.py
@@ -56,7 +56,9 @@ class Utils:
 
     @staticmethod
     def get_environment_prefix() -> str:
-        return "/meteor" if get_settings().ENVIRONMENT in ["stage", "prod"] else ""
+        if get_settings().ENVIRONMENT not in ["stage", "prod"]:
+            return ""
+        return get_settings().CUSTOM_PATH or "/meteor"
 
     @staticmethod
     def verify_file(file: UploadFile) -> None:


### PR DESCRIPTION
This pull request makes it possible to run the REST service on a different path than the default `/meteor`.