### PR TITLE
fix: catch apostrophes in author names (TT-989)

### DIFF
--- a/metadata_extract/text.py
+++ b/metadata_extract/text.py
@@ -27,8 +27,8 @@ __PATTERNS: dict[str, regex.regex.Pattern[str]] = {
     'type_pattern_2': regex.compile(r'\bNOU\b'),
     'no_letters_pattern': regex.compile(r'^[\W\d]+$'),
     'name_pattern': regex.compile(
-        r"\b[^\P{Lu}][^\P{Ll}]*[-|‐]?[^\P{Lu}]?[^\P{Ll}’]*\.?" +
-        r"(?: [^\P{Lu}][^\P{Ll}’]*[-|‐]?[^\P{Lu}]?[^\P{Ll}]*\.?)+\b(?! *\()"),
+        r"\b[^\P{Lu}][‘’‛′']?[^\P{Ll}]*[-|‐]?[^\P{Lu}]?[‘’‛′']?[^\P{Ll}]*\.?" +
+        r"(?: [^\P{Lu}][‘’‛′']?[^\P{Ll}]*[-|‐]?[^\P{Lu}]?[‘’‛′']?[^\P{Ll}]*\.?)+\b(?! *\()"),
     'parenthesis_pattern': regex.compile(r"\(.*?\)"),
     'double_capital_letter_pattern': regex.compile(r"\b[A-Z]{2,}\b"),
     'non_alphanumeric_pattern': regex.compile(r"\W+")

--- a/test/test_infopage.py
+++ b/test/test_infopage.py
@@ -33,4 +33,4 @@ def test_find_isxn():
 def test_find_authors():
     authors = test_infopage.find_author()
     assert set(authors) == {'Bjørnstjerne M. Bjørnson', 'Jacobine Camilla-Collett',
-                            'Henrik J. Ibsen', 'Raymond McArthur', 'John O'}
+                            'Henrik J. Ibsen', 'Raymond McArthur', 'John O’Toole'}

--- a/test/test_pdf.py
+++ b/test/test_pdf.py
@@ -91,7 +91,7 @@ def test_authors():
         },
         {
             "firstname": "John",
-            "lastname": "O",
+            "lastname": "O’Toole",
             "origin": {
                 "type": "INFO_PAGE",
                 "pageNumber": 2


### PR DESCRIPTION
Fixes an error in the regex that no longer caught apostrophes in author names, leading to only partial matches. This fix also adds more variations of apostrophes to match against for better results.