### PR TITLE
feat: Identify outdated authority posts and sort them last

### DIFF
--- a/metadata_extract/registry.py
+++ b/metadata_extract/registry.py
@@ -58,7 +58,7 @@ class PublisherRegistry:
             "SELECT DISTINCT O1.id, O2.name FROM " +
             "organizations O1 JOIN organizations O2 USING(id) " +
             f"WHERE {self.field} = '{escaped_pattern}' AND " +
-            "O2.standard=1 ORDER BY O1.standard DESC, O1.category DESC"
+            "O2.standard=1 ORDER BY O1.outdated, O1.standard DESC, O1.category DESC"
         )
         rows = self.cursor.fetchall()
         results: list[RegistryType] = []


### PR DESCRIPTION
Some organization names are present twice in the Norwegian Authority File, with one post referring to the current name / organization, and the other referring to a previous instance.
This information is written in free text, in different ways ("Gjelder fra YYYY", "Gjelder perioden YYYY-YYYY", "Gjelder til DD.MM.YYYY"...), in MARC field 678a or 680a. The `text_outdated` method looks for simple patterns in these fields. It does not catch all instances of outdated posts, but has given high enough accuracy in tests.