### PR TITLE
perf: Use flag to skip images in page blocks (TT-1336)

### DIFF
--- a/metadata_extract/page.py
+++ b/metadata_extract/page.py
@@ -42,8 +42,9 @@ class Page:
                  alto_file: Optional[AltoFile] = None):
         self.text_blocks = []
         if pdf_page:
-            blocks = pdf_page.get_text("dict")['blocks']
-            for block in blocks:
+            page_text = pdf_page.get_text("dict",
+                                          flags=fitz.TEXTFLAGS_DICT & ~fitz.TEXT_PRESERVE_IMAGES)
+            for block in page_text["blocks"]:
                 if 'lines' not in block.keys():
                     continue
                 for line in block['lines']:


### PR DESCRIPTION
I tested this change on a set of 150 large PDF files, and the total execution time dropped from ca. 10 minutes to 2 minutes.