### PR TITLE
More robust URL verification using HEAD requests

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -83,7 +83,7 @@ class Utils:
                 content_size = response.headers['Content-Length']
                 if int(content_size) > size_limit * 1024 * 1024:
                     raise HTTPException(status_code=400, detail="File too large")
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             pass
 
     @staticmethod


### PR DESCRIPTION
I noticed that when submitting a document by URL to Meteor, some documents will cause an Internal server error.  Examples of URLs that trigger this:

* https://www.hi.no/templates/reporteditor/report-pdf?id=94329&25068186
* https://www.julkari.fi/bitstream/handle/10024/143710/rinta-kokko_hanna_dissertation_2022.pdf

Here is a typical traceback:

```
INFO:     10.12.56.2:51974 - "POST / HTTP/1.0" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 426, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1106, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 91, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 146, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 274, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-docker/src/routes/extract.py", line 37, in post_pdf_html
    utils.verify_url(file_url)
  File "/python-docker/src/util.py", line 93, in verify_url
    content_size = requests.get(url, stream=True, timeout=30).headers['Content-length']
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
           ~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'content-length'
```

The problem is that Meteor expects the remote HTTP server to provide a "Content-Length" header, because the size of the document is checked against the `MAX_FILE_SIZE_MB` configuration setting to make sure that the file is not too large. But not all servers support this header, and when they don't provide it, the `verify_url` function will raise the above KeyError exception.

This PR changes the Meteor code to be more robust. The `verify_url` function still performs a "preflight" HTTP request (now a HEAD instead of a GET, which is more efficient) and tries to find out the Content-Length. But if that fails for any reason, the `verify_url` function will still pass. 

The `download_file` function is modified to perform the download in 1MB chunks and to verify the file size along the way so that it doesn't exceed the limit (it will stop early if that happens). Thus, too large files will still be detected even if the HEAD / Content-Length method fails, it just happens a bit later.